### PR TITLE
Fix UndefVarError: tree_name not defined in XsdToStruct

### DIFF
--- a/XsdToStruct.jl/src/xsd_reader/xsd_reader.jl
+++ b/XsdToStruct.jl/src/xsd_reader/xsd_reader.jl
@@ -42,7 +42,7 @@ function create_xsd_tree(xsd_root::XMLElement)::SchemaTreeNode
             child_name = LightXML.name(xsd_child_element)
 
             if child_name == "element"
-                root_field, child_node = parse_xsd_element_child(xsd_child_element, tree_name)
+                root_field, child_node = parse_xsd_element_child(xsd_child_element, xml_namespace)
                 push!(child_nodes, child_node)
             elseif child_name == "complexType"
                 child_node = parse_xsd_complex_type(xsd_child_element)

--- a/XsdToStruct.jl/test/test_data/generic_data/root_element_inline_type.xsd
+++ b/XsdToStruct.jl/test/test_data/generic_data/root_element_inline_type.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:TestRootElementInlineType="TestRootElementInlineType" targetNamespace="TestRootElementInlineType">
+
+    <element name="document">
+        <annotation>
+            <documentation>The root element defines its type inline instead of referencing a named complexType.</documentation>
+        </annotation>
+        <complexType>
+            <sequence>
+                <element name="Element_string" type="string"/>
+                <element name="Element_double" type="double"/>
+            </sequence>
+        </complexType>
+    </element>
+
+</schema>

--- a/XsdToStruct.jl/test/test_data/generic_data/root_element_inline_type/root_element_inline_type.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/root_element_inline_type/root_element_inline_type.jl
@@ -1,0 +1,42 @@
+"""
+    module TestRootElementInlineType
+
+This module was generated with XsdToStruct version 0.1.0 from "root_element_inline_type.xsd".
+All generated types are exported by this module and some meta data is included in the submodule __meta.
+
+In order to use this module the following dependencies need to be installed:
+    AbstractXsdTypes
+    Reexport
+
+This module can be used/import as follows:
+
+```julia
+include("path/to/root_element_inline_type.jl")
+using .TestRootElementInlineType
+```
+or:
+```julia
+include("path/to/root_element_inline_type.jl")
+import .TestRootElementInlineType
+```
+"""
+module TestRootElementInlineType
+
+using Reexport
+
+@reexport using AbstractXsdTypes
+
+include("root_element_inline_type_struct.jl")
+@reexport using .TestRootElementInlineType_struct
+
+module __meta
+
+    import ..TestRootElementInlineType_struct
+
+    root_type = TestRootElementInlineType_struct.document
+    xsd_filename = "root_element_inline_type.xsd"
+    XsdToStruct_version = "0.1.0"
+
+end
+
+end

--- a/XsdToStruct.jl/test/test_data/generic_data/root_element_inline_type/root_element_inline_type_struct.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/root_element_inline_type/root_element_inline_type_struct.jl
@@ -1,0 +1,14 @@
+module TestRootElementInlineType_struct
+
+import AbstractXsdTypes
+
+Base.@kwdef struct document <: AbstractXsdTypes.AbstractXSDComplex
+    Element_string::String
+    Element_double::Float64
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export document
+
+end


### PR DESCRIPTION
## Summary
- `create_xsd_tree` referenced an undefined `tree_name` variable when the schema's root `<element>` declares its type inline (a nested `complexType`/`simpleType`) instead of via a `type` attribute.
- Replaced it with `xml_namespace`, the enclosing schema's name, matching how `parse_xsd_element_child` is called elsewhere (e.g. `xsd_reader_complex_node.jl:63` passes `name(complex_node)`).

Fixes #73

## Test plan
- [x] Added `test/test_data/generic_data/root_element_inline_type.xsd`, a minimal schema whose root element defines its type inline, reproducing the reported crash.
- [x] Generated the expected golden output (`root_element_inline_type.jl` / `root_element_inline_type_struct.jl`) with the fix applied, following the existing golden-file test convention.
- [x] `Pkg.test()` passes locally (102 tests, including the new fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)