### PR TITLE
Support xs:date / xs:dateTime restrictions, fix namespace-prefixed type detection

### DIFF
--- a/AbstractXsdTypes.jl/Project.toml
+++ b/AbstractXsdTypes.jl/Project.toml
@@ -4,10 +4,11 @@ authors = ["Tom Lemmens", "Matthijs Cox"]
 version = "0.1.0"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
 Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
 
 [compat]
-julia = "1.6"
 Format = "1"
 Memoization = "0.2"
+julia = "1.6"

--- a/AbstractXsdTypes.jl/src/AbstractXsdTypes.jl
+++ b/AbstractXsdTypes.jl/src/AbstractXsdTypes.jl
@@ -2,6 +2,7 @@ module AbstractXsdTypes
 
 using Memoization
 using Format
+using Dates
 
 include("type_definitions.jl")
 include("construction_and_conversion_functions.jl")

--- a/AbstractXsdTypes.jl/src/type_definitions.jl
+++ b/AbstractXsdTypes.jl/src/type_definitions.jl
@@ -133,6 +133,33 @@ Base.iterate(s::AbstractXSDString) = iterate(s.value)
 Base.isvalid(s::AbstractXSDString, i::Integer) = isvalid(s.value, i)
 
 """
+    AbstractXSDDateTime <: Dates.AbstractDateTime
+
+Must have a `value` field, an `__xml_attributes` field, and a __validated field.
+
+```jldoctest datetimetype
+import AbstractXsdTypes: AbstractXSDDateTime
+using Dates
+
+struct DateTimeType <: AbstractXSDDateTime
+    value::DateTime
+    __xml_attributes::Union{Nothing,Dict{String,String}}
+    __validated::Bool
+end
+
+xsd_datetime = DateTimeType(DateTime(2024, 1, 1), Dict("x" => "y"), true)
+show(xsd_datetime)
+
+# output
+
+Dates.DateTime("2024-01-01T00:00:00")
+```
+"""
+abstract type AbstractXSDDateTime <: Dates.AbstractDateTime end
+
+can_be_converted(from::Type{<:Dates.AbstractDateTime}, to::Type{<:AbstractXSDDateTime}) = true
+
+"""
     AbstractXSDComplex
 
 Abstract type used for complex XSD structs.
@@ -238,7 +265,7 @@ end
 
 # Collections of XSD types
 const AbstractXSDNumericTypes = Union{AbstractXSDFloat,AbstractXSDUnsigned,AbstractXSDSigned}
-const AbstractXSDSimpleTypes = Union{AbstractXSDNumericTypes,AbstractXSDString}
+const AbstractXSDSimpleTypes = Union{AbstractXSDNumericTypes,AbstractXSDString,AbstractXSDDateTime}
 const AbstractXSDSimpleUnionTypes = Union{AbstractXSDSimpleTypes,AbstractXSDUnion}
 const AbstractXSDAllTypes = Union{AbstractXSDSimpleTypes,AbstractXSDComplex,AbstractXSDUnion}
 

--- a/AbstractXsdTypes.jl/src/type_definitions.jl
+++ b/AbstractXsdTypes.jl/src/type_definitions.jl
@@ -160,6 +160,33 @@ abstract type AbstractXSDDateTime <: Dates.AbstractDateTime end
 can_be_converted(from::Type{<:Dates.AbstractDateTime}, to::Type{<:AbstractXSDDateTime}) = true
 
 """
+    AbstractXSDDate <: Dates.TimeType
+
+Must have a `value` field, an `__xml_attributes` field, and a __validated field.
+
+```jldoctest datetype
+import AbstractXsdTypes: AbstractXSDDate
+using Dates
+
+struct DateType <: AbstractXSDDate
+    value::Date
+    __xml_attributes::Union{Nothing,Dict{String,String}}
+    __validated::Bool
+end
+
+xsd_date = DateType(Date(2024, 1, 1), Dict("x" => "y"), true)
+show(xsd_date)
+
+# output
+
+Dates.Date("2024-01-01")
+```
+"""
+abstract type AbstractXSDDate <: Dates.TimeType end
+
+can_be_converted(from::Type{<:Dates.TimeType}, to::Type{<:AbstractXSDDate}) = true
+
+"""
     AbstractXSDComplex
 
 Abstract type used for complex XSD structs.
@@ -265,7 +292,7 @@ end
 
 # Collections of XSD types
 const AbstractXSDNumericTypes = Union{AbstractXSDFloat,AbstractXSDUnsigned,AbstractXSDSigned}
-const AbstractXSDSimpleTypes = Union{AbstractXSDNumericTypes,AbstractXSDString,AbstractXSDDateTime}
+const AbstractXSDSimpleTypes = Union{AbstractXSDNumericTypes,AbstractXSDString,AbstractXSDDateTime,AbstractXSDDate}
 const AbstractXSDSimpleUnionTypes = Union{AbstractXSDSimpleTypes,AbstractXSDUnion}
 const AbstractXSDAllTypes = Union{AbstractXSDSimpleTypes,AbstractXSDComplex,AbstractXSDUnion}
 

--- a/AbstractXsdTypes.jl/test/Project.toml
+++ b/AbstractXsdTypes.jl/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReTest = "e0db7c4e-2690-44b9-bad6-7687da720f89"

--- a/XsdToStruct.jl/src/xsd_field_data/xsd_field_data_type_mapping.jl
+++ b/XsdToStruct.jl/src/xsd_field_data/xsd_field_data_type_mapping.jl
@@ -19,6 +19,7 @@ const built_in_data_type_dict = Dict([
     ("double", "Float64"),
     ("boolean", "Bool"),
     ("dateTime", "Union{ZonedDateTime, DateTime}"),
+    ("date", "Date"),
     ("integer", "Int64"),
     ("int", "Int64"),
     ("nonNegativeInteger", "UInt64"),
@@ -28,7 +29,9 @@ const built_in_data_type_dict = Dict([
 get_julia_type(type_name::AbstractString)::String = get(built_in_data_type_dict, type_name, type_name)
 
 # TODO:for now ignore namespace stuff
-parse_xsd_type_to_julia_type(type_string::AbstractString)::String = get_julia_type(split(type_string, ":")[end])
+strip_xsd_namespace(type_string::AbstractString)::AbstractString = split(type_string, ":")[end]
+
+parse_xsd_type_to_julia_type(type_string::AbstractString)::String = get_julia_type(strip_xsd_namespace(type_string))
 
 # determine type properties from the given xsd attribute dictionary
 function is_vector(xsd_attributes::OptionalDictStringString)::Bool

--- a/XsdToStruct.jl/src/xsd_field_data/xsd_field_data_types.jl
+++ b/XsdToStruct.jl/src/xsd_field_data/xsd_field_data_types.jl
@@ -1,7 +1,7 @@
 
 abstract type AbstractFieldData end
 
-has_datetime(field::AbstractFieldData)::Bool = false
+has_xsd_type(field::AbstractFieldData, xsd_type_name::AbstractString)::Bool = false
 
 const OptionalDictStringString = Union{Nothing,Dict{<:AbstractString,<:AbstractString}}
 
@@ -16,7 +16,8 @@ Base.@kwdef mutable struct FieldData <: AbstractFieldData
     can_be_missing = can_be_missing(xsd_attributes)
 end
 
-has_datetime(field::FieldData)::Bool = field.xsd_type == "dateTime"
+has_xsd_type(field::FieldData, xsd_type_name::AbstractString)::Bool =
+    strip_xsd_namespace(field.xsd_type) == xsd_type_name
 
 Base.@kwdef mutable struct ChoiceFieldData <: AbstractFieldData
     name::String
@@ -34,19 +35,8 @@ Base.@kwdef mutable struct GroupFieldData <: AbstractFieldData
     xsd_attributes::OptionalDictStringString = nothing
 end
 
-function has_datetime(field::ChoiceFieldData)::Bool
-    has_datetime = false
-
-    for choice in field.choice_options
-        has_datetime = choice.xsd_type == "dateTime"
-
-        if has_datetime
-            # we already found a matching node stop looking
-            break
-        end
-    end
-
-    return has_datetime
+function has_xsd_type(field::ChoiceFieldData, xsd_type_name::AbstractString)::Bool
+    return any(choice -> strip_xsd_namespace(choice.xsd_type) == xsd_type_name, field.choice_options)
 end
 
 """

--- a/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_simple.jl
+++ b/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_simple.jl
@@ -59,7 +59,8 @@ const xsd_abstract_type_map = Dict((
 	Signed => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDSigned",
 	Unsigned => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDUnsigned",
 	AbstractString => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDString",
-	Dates.AbstractDateTime => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDDateTime"))
+	Dates.AbstractDateTime => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDDateTime",
+	Dates.TimeType => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDDate"))
 
 function get_supertype(type_string::AbstractString)
 	if type_string == "Union{ZonedDateTime, DateTime}"

--- a/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_simple.jl
+++ b/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_simple.jl
@@ -58,7 +58,8 @@ const xsd_abstract_type_map = Dict((
 	AbstractFloat => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDFloat",
 	Signed => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDSigned",
 	Unsigned => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDUnsigned",
-	AbstractString => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDString"))
+	AbstractString => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDString",
+	Dates.AbstractDateTime => "$ABSTRACT_TYPE_PACKAGE.AbstractXSDDateTime"))
 
 function get_supertype(type_string::AbstractString)
 	if type_string == "Union{ZonedDateTime, DateTime}"

--- a/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_struct.jl
+++ b/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_struct.jl
@@ -5,10 +5,12 @@ include("xsd_module_builder_union.jl")
 function write_struct_module_to_io(xsd_module_builder::XSDStructModuleBuilderType)::Nothing
     print(xsd_module_builder.io_struct, "module $(xsd_module_builder.module_name_struct)\n\n")
 
-    if xsd_module_builder.xsd_tree.requires_TimeZones
+    if xsd_module_builder.xsd_tree.requires_Dates
         print(xsd_module_builder.io_struct, "using Reexport\n")
         print(xsd_module_builder.io_struct, "@reexport using Dates\n")
-        print(xsd_module_builder.io_struct, "@reexport using TimeZones\n")
+        if xsd_module_builder.xsd_tree.requires_TimeZones
+            print(xsd_module_builder.io_struct, "@reexport using TimeZones\n")
+        end
     end
 
     writeln(xsd_module_builder, IOStruct, "import $ABSTRACT_TYPE_PACKAGE")

--- a/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_top.jl
+++ b/XsdToStruct.jl/src/xsd_module_builder/xsd_module_builder_top.jl
@@ -49,8 +49,10 @@ function write_docstring_part(xsd_module_builder::XSDStructModuleBuilderType)::N
     writeln(xsd_module_builder, IOTop, "In order to use this module the following dependencies need to be installed:")
     writeln(xsd_module_builder, IOTop, "AbstractXsdTypes", indent_level = 1)
     writeln(xsd_module_builder, IOTop, "Reexport", indent_level = 1)
-    if xsd_module_builder.xsd_tree.requires_TimeZones
+    if xsd_module_builder.xsd_tree.requires_Dates
         writeln(xsd_module_builder, IOTop, "Dates", indent_level = 1)
+    end
+    if xsd_module_builder.xsd_tree.requires_TimeZones
         writeln(xsd_module_builder, IOTop, "TimeZones", indent_level = 1)
     end
     writeln(xsd_module_builder, IOTop)

--- a/XsdToStruct.jl/src/xsd_tree/xsd_tree_node_types.jl
+++ b/XsdToStruct.jl/src/xsd_tree/xsd_tree_node_types.jl
@@ -106,6 +106,7 @@ Base.@kwdef struct SchemaTreeNode <: AbstractTreeNode
     has_simple_nodes::Bool
     has_complex_nodes::Bool
     requires_TimeZones::Bool
+    requires_Dates::Bool
     group_nodes::Vector{ComplexTreeNode} = Vector{ComplexTreeNode}()
     child_nodes::Vector{AbstractTreeNode} = Vector{AbstractTreeNode}()
 end

--- a/XsdToStruct.jl/src/xsd_tree/xsd_tree_utilities.jl
+++ b/XsdToStruct.jl/src/xsd_tree/xsd_tree_utilities.jl
@@ -36,73 +36,73 @@ function has_node_of_type(children::Vector{<:AbstractTreeNode}, ::Type{T})::Bool
     return has_nodes_of_type
 end
 
-function has_datetime_field(complex_node::ComplexTreeNode)::Bool
+function has_xsd_type_field(complex_node::ComplexTreeNode, xsd_type_name::AbstractString)::Bool
     # check if any child nodes match
-    has_datetime_field = has_dateTime(complex_node.child_nodes)
-    if has_datetime_field
+    found = has_xsd_type_node(complex_node.child_nodes, xsd_type_name)
+    if found
         # we already found a matching node stop looking
-        return has_datetime_field
+        return found
     end
 
     # check if any fields match
     for field in get_all_fields(complex_node)
-        has_datetime_field = has_datetime(field)
+        found = has_xsd_type(field, xsd_type_name)
 
-        if has_datetime_field
+        if found
             # we already found a matching node stop looking
-            return has_datetime_field
+            return found
         end
     end
 
-    return has_datetime_field
+    return found
 end
 
-function has_datetime_field(extension_node::ExtensionTreeNode)::Bool
+function has_xsd_type_field(extension_node::ExtensionTreeNode, xsd_type_name::AbstractString)::Bool
     # check if own content matches
-    has_datetime_field = has_dateTime(extension_node.node_content)
-    if has_datetime_field
+    found = has_xsd_type_node(extension_node.node_content, xsd_type_name)
+    if found
         # we already found a matching node stop looking
-        return has_datetime_field
+        return found
     end
 
     # check if any child nodes match
-    has_datetime_field = has_dateTime(extension_node.base_children)
-    if has_datetime_field
+    found = has_xsd_type_node(extension_node.base_children, xsd_type_name)
+    if found
         # we already found a matching node stop looking
-        return has_datetime_field
+        return found
     end
 
     # check if any fields match
     for field in extension_node.base_fields
-        has_datetime_field = has_datetime(field)
+        found = has_xsd_type(field, xsd_type_name)
 
-        if has_datetime_field
+        if found
             # we already found a matching node stop looking
-            return has_datetime
+            return found
         end
     end
 
-    return has_datetime_field
+    return found
 end
 
-function has_dateTime(children::Vector{AbstractTreeNode})::Bool
-    has_datetime_node = false
+function has_xsd_type_node(children::Vector{AbstractTreeNode}, xsd_type_name::AbstractString)::Bool
+    found = false
 
     for child in children
         if typeof(child) == SimpleTreeNode
-            # check if node base type matches dateTime
-            has_datetime_node = child.field.xsd_type == "dateTime"
+            # check if node base type matches
+            found = strip_xsd_namespace(child.field.xsd_type) == xsd_type_name
         elseif typeof(child) == ComplexTreeNode || typeof(child) == ExtensionTreeNode
-            has_datetime_node = has_datetime_field(child)
+            found = has_xsd_type_field(child, xsd_type_name)
         end
 
-        if has_datetime_node
+        if found
             # we already found a matching note stop looking
             break
         end
     end
 
-    return has_datetime_node
+    return found
 end
 
 function create_SchemaTreeNode(;
@@ -116,7 +116,8 @@ function create_SchemaTreeNode(;
     has_complex_nodes =
         (has_node_of_type(child_nodes, ComplexTreeNode) || has_node_of_type(group_nodes, ComplexTreeNode))
 
-    requires_TimeZones = has_dateTime(child_nodes)
+    requires_TimeZones = has_xsd_type_node(child_nodes, "dateTime")
+    requires_Dates = requires_TimeZones || has_xsd_type_node(child_nodes, "date")
 
     return SchemaTreeNode(
         common_data = CommonNodeData(name = name, attributes = attributes),
@@ -126,6 +127,7 @@ function create_SchemaTreeNode(;
         has_simple_nodes = has_simple_nodes,
         has_complex_nodes = has_complex_nodes,
         requires_TimeZones = requires_TimeZones,
+        requires_Dates = requires_Dates,
     )
 end
 

--- a/XsdToStruct.jl/test/test_data/generic_data/date_restriction.xsd
+++ b/XsdToStruct.jl/test/test_data/generic_data/date_restriction.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:TestDateRestriction="TestDateRestriction" targetNamespace="TestDateRestriction">
+
+<element name="document" type="TestDateRestriction:documentType"/>
+
+<simpleType name="TestSimpleType1">
+    <annotation>
+        <documentation>An example of a date based simple type without restriction facets.</documentation>
+    </annotation>
+    <restriction base="date"/>
+</simpleType>
+
+<complexType name="documentType">
+    <sequence>
+        <element name="TestElement1" type="TestDateRestriction:TestSimpleType1"/>
+    </sequence>
+</complexType>
+
+</schema>

--- a/XsdToStruct.jl/test/test_data/generic_data/date_restriction/date_restriction.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/date_restriction/date_restriction.jl
@@ -1,0 +1,43 @@
+"""
+    module TestDateRestriction
+
+This module was generated with XsdToStruct version 0.1.0 from "date_restriction.xsd".
+All generated types are exported by this module and some meta data is included in the submodule __meta.
+
+In order to use this module the following dependencies need to be installed:
+    AbstractXsdTypes
+    Reexport
+    Dates
+
+This module can be used/import as follows:
+
+```julia
+include("path/to/date_restriction.jl")
+using .TestDateRestriction
+```
+or:
+```julia
+include("path/to/date_restriction.jl")
+import .TestDateRestriction
+```
+"""
+module TestDateRestriction
+
+using Reexport
+
+@reexport using AbstractXsdTypes
+
+include("date_restriction_struct.jl")
+@reexport using .TestDateRestriction_struct
+
+module __meta
+
+    import ..TestDateRestriction_struct
+
+    root_type = TestDateRestriction_struct.documentType
+    xsd_filename = "date_restriction.xsd"
+    XsdToStruct_version = "0.1.0"
+
+end
+
+end

--- a/XsdToStruct.jl/test/test_data/generic_data/date_restriction/date_restriction_struct.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/date_restriction/date_restriction_struct.jl
@@ -1,0 +1,26 @@
+module TestDateRestriction_struct
+
+using Reexport
+@reexport using Dates
+import AbstractXsdTypes
+
+"""
+An example of a date based simple type without restriction facets.
+"""
+Base.@kwdef struct TestSimpleType1 <: AbstractXsdTypes.AbstractXSDDate
+    value::Date
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export TestSimpleType1
+
+Base.@kwdef struct documentType <: AbstractXsdTypes.AbstractXSDComplex
+    TestElement1::TestSimpleType1
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export documentType
+
+end

--- a/XsdToStruct.jl/test/test_data/generic_data/datetime_restriction.xsd
+++ b/XsdToStruct.jl/test/test_data/generic_data/datetime_restriction.xsd
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:TestDateTimeRestriction="TestDateTimeRestriction" targetNamespace="TestDateTimeRestriction">
+
+<element name="document" type="TestDateTimeRestriction:documentType"/>
+
+<simpleType name="TestSimpleType1">
+    <annotation>
+        <documentation>An example of a dateTime based simple type without restriction facets.</documentation>
+    </annotation>
+    <restriction base="dateTime"/>
+</simpleType>
+
+<complexType name="documentType">
+    <sequence>
+        <element name="TestElement1" type="TestDateTimeRestriction:TestSimpleType1"/>
+    </sequence>
+</complexType>
+
+</schema>

--- a/XsdToStruct.jl/test/test_data/generic_data/datetime_restriction/datetime_restriction.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/datetime_restriction/datetime_restriction.jl
@@ -1,0 +1,44 @@
+"""
+    module TestDateTimeRestriction
+
+This module was generated with XsdToStruct version 0.1.0 from "datetime_restriction.xsd".
+All generated types are exported by this module and some meta data is included in the submodule __meta.
+
+In order to use this module the following dependencies need to be installed:
+    AbstractXsdTypes
+    Reexport
+    Dates
+    TimeZones
+
+This module can be used/import as follows:
+
+```julia
+include("path/to/datetime_restriction.jl")
+using .TestDateTimeRestriction
+```
+or:
+```julia
+include("path/to/datetime_restriction.jl")
+import .TestDateTimeRestriction
+```
+"""
+module TestDateTimeRestriction
+
+using Reexport
+
+@reexport using AbstractXsdTypes
+
+include("datetime_restriction_struct.jl")
+@reexport using .TestDateTimeRestriction_struct
+
+module __meta
+
+    import ..TestDateTimeRestriction_struct
+
+    root_type = TestDateTimeRestriction_struct.documentType
+    xsd_filename = "datetime_restriction.xsd"
+    XsdToStruct_version = "0.1.0"
+
+end
+
+end

--- a/XsdToStruct.jl/test/test_data/generic_data/datetime_restriction/datetime_restriction_struct.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/datetime_restriction/datetime_restriction_struct.jl
@@ -1,0 +1,27 @@
+module TestDateTimeRestriction_struct
+
+using Reexport
+@reexport using Dates
+@reexport using TimeZones
+import AbstractXsdTypes
+
+"""
+An example of a dateTime based simple type without restriction facets.
+"""
+Base.@kwdef struct TestSimpleType1 <: AbstractXsdTypes.AbstractXSDDateTime
+    value::Union{ZonedDateTime, DateTime}
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export TestSimpleType1
+
+Base.@kwdef struct documentType <: AbstractXsdTypes.AbstractXSDComplex
+    TestElement1::TestSimpleType1
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export documentType
+
+end

--- a/XsdToStruct.jl/test/test_data/generic_data/namespaced_datetime_restriction.xsd
+++ b/XsdToStruct.jl/test/test_data/generic_data/namespaced_datetime_restriction.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:TestNamespacedDateTimeRestriction="TestNamespacedDateTimeRestriction" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="TestNamespacedDateTimeRestriction">
+
+<element name="document" type="TestNamespacedDateTimeRestriction:documentType"/>
+
+<simpleType name="ISODate">
+    <annotation>
+        <documentation>A date based simple type with a namespace-prefixed restriction base, as commonly seen in real-world XSDs (e.g. ISO 20022).</documentation>
+    </annotation>
+    <restriction base="xs:date"/>
+</simpleType>
+
+<simpleType name="ISODateTime">
+    <annotation>
+        <documentation>A dateTime based simple type with a namespace-prefixed restriction base.</documentation>
+    </annotation>
+    <restriction base="xs:dateTime"/>
+</simpleType>
+
+<complexType name="documentType">
+    <sequence>
+        <element name="TestElement1" type="TestNamespacedDateTimeRestriction:ISODate"/>
+        <element name="TestElement2" type="TestNamespacedDateTimeRestriction:ISODateTime"/>
+    </sequence>
+</complexType>
+
+</schema>

--- a/XsdToStruct.jl/test/test_data/generic_data/namespaced_datetime_restriction/namespaced_datetime_restriction.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/namespaced_datetime_restriction/namespaced_datetime_restriction.jl
@@ -1,0 +1,44 @@
+"""
+    module TestNamespacedDateTimeRestriction
+
+This module was generated with XsdToStruct version 0.1.0 from "namespaced_datetime_restriction.xsd".
+All generated types are exported by this module and some meta data is included in the submodule __meta.
+
+In order to use this module the following dependencies need to be installed:
+    AbstractXsdTypes
+    Reexport
+    Dates
+    TimeZones
+
+This module can be used/import as follows:
+
+```julia
+include("path/to/namespaced_datetime_restriction.jl")
+using .TestNamespacedDateTimeRestriction
+```
+or:
+```julia
+include("path/to/namespaced_datetime_restriction.jl")
+import .TestNamespacedDateTimeRestriction
+```
+"""
+module TestNamespacedDateTimeRestriction
+
+using Reexport
+
+@reexport using AbstractXsdTypes
+
+include("namespaced_datetime_restriction_struct.jl")
+@reexport using .TestNamespacedDateTimeRestriction_struct
+
+module __meta
+
+    import ..TestNamespacedDateTimeRestriction_struct
+
+    root_type = TestNamespacedDateTimeRestriction_struct.documentType
+    xsd_filename = "namespaced_datetime_restriction.xsd"
+    XsdToStruct_version = "0.1.0"
+
+end
+
+end

--- a/XsdToStruct.jl/test/test_data/generic_data/namespaced_datetime_restriction/namespaced_datetime_restriction_struct.jl
+++ b/XsdToStruct.jl/test/test_data/generic_data/namespaced_datetime_restriction/namespaced_datetime_restriction_struct.jl
@@ -1,0 +1,39 @@
+module TestNamespacedDateTimeRestriction_struct
+
+using Reexport
+@reexport using Dates
+@reexport using TimeZones
+import AbstractXsdTypes
+
+"""
+A date based simple type with a namespace-prefixed restriction base, as commonly seen in real-world XSDs (e.g. ISO 20022).
+"""
+Base.@kwdef struct ISODate <: AbstractXsdTypes.AbstractXSDDate
+    value::Date
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export ISODate
+
+"""
+A dateTime based simple type with a namespace-prefixed restriction base.
+"""
+Base.@kwdef struct ISODateTime <: AbstractXsdTypes.AbstractXSDDateTime
+    value::Union{ZonedDateTime, DateTime}
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export ISODateTime
+
+Base.@kwdef struct documentType <: AbstractXsdTypes.AbstractXSDComplex
+    TestElement1::ISODate
+    TestElement2::ISODateTime
+    __xml_attributes::Union{Nothing, Dict{String, String}} = nothing
+    __validated::Bool = true
+end
+
+export documentType
+
+end

--- a/XsdToStruct.jl/test/test_generated_module.jl
+++ b/XsdToStruct.jl/test/test_generated_module.jl
@@ -220,6 +220,20 @@
         @test doc_type isa TestTypeInType.documentType
     end
 
+    @testset "test generated namespaced_datetime_restriction" begin
+        include(joinpath(generic_data_dir, "namespaced_datetime_restriction", "namespaced_datetime_restriction.jl"))
+        import .TestNamespacedDateTimeRestriction
+
+        date_value = TestNamespacedDateTimeRestriction.ISODate(Date(2024, 1, 1))
+        @test date_value isa TestNamespacedDateTimeRestriction.ISODate
+
+        datetime_value = TestNamespacedDateTimeRestriction.ISODateTime(DateTime(2024, 1, 1))
+        @test datetime_value isa TestNamespacedDateTimeRestriction.ISODateTime
+
+        doc_type = TestNamespacedDateTimeRestriction.documentType(date_value, datetime_value)
+        @test doc_type isa TestNamespacedDateTimeRestriction.documentType
+    end
+
     @testset "test generated union" begin
         include(joinpath(generic_data_dir, "union_types", "union_types.jl"))
         import .TestSimpleUnion


### PR DESCRIPTION
## Summary
- `get_simple_node_super_type` crashed with `KeyError: key Dates.AbstractDateTime not found` whenever a schema declared a simpleType restricting `xs:dateTime` (e.g. `<xs:restriction base="xs:dateTime"/>`), because `xsd_abstract_type_map` had no entry for the special-cased `Dates.AbstractDateTime` supertype used for dateTime fields.
- `xs:date` was silently unsupported (dropped with a "still missing" warning, no error) since `"date"` was never in `built_in_data_type_dict`.
- Added `AbstractXSDDateTime <: Dates.AbstractDateTime` and `AbstractXSDDate <: Dates.TimeType` to `AbstractXsdTypes.jl`, mirroring the existing `AbstractXSDFloat`/`Signed`/`Unsigned`/`String` pattern, and wired both into `XsdToStruct`'s abstract type map plus the `"date"`/`"dateTime"` built-in type mapping.
- Decoupled the generated module's `Dates` reexport from the `TimeZones`-specific one (`requires_Dates` alongside `requires_TimeZones` on `SchemaTreeNode`), since a date-only schema needs `Dates` but not `TimeZones`/`ZonedDateTime`.
- Fixed `has_xsd_type` detection to strip XSD namespace prefixes before comparing against the target type name. Previously only unprefixed base types (`base="dateTime"`) were detected as needing `Dates`/`TimeZones` imports; real-world schemas that alias the XSD namespace to a prefix (`base="xs:dateTime"`, as in the reported MWE and common in ISO 20022/SWIFT schemas) generated a module referencing `Date`/`DateTime`/`ZonedDateTime` without importing them - broken code that would only fail later, when someone tried to load it.

Fixes #76

## Test plan
- [x] Reproduced the reported crash with the issue's exact MWE, confirmed it's fixed.
- [x] Added `datetime_restriction.xsd`, `date_restriction.xsd`, and `namespaced_datetime_restriction.xsd` golden-file fixtures (the last one matches the reported MWE's `xmlns:xs` prefixing style) to `XsdToStruct.jl/test/test_data/generic_data/`.
- [x] Extended `test_generated_module.jl` to actually `include()` the generated namespaced module and construct `ISODate`/`ISODateTime`/`documentType` instances, not just compare generated text.
- [x] `Pkg.test()` passes for both `AbstractXsdTypes.jl` (1688 tests, including doctests) and `XsdToStruct.jl` (109 tests).
- [x] Manually verified the generated module for the reported MWE loads and constructs successfully in a fresh environment with `AbstractXsdTypes`, `Dates`, `TimeZones`, `Reexport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)