### PR TITLE
Raise a clear error for group refs inside a choice element

### DIFF
--- a/XsdToStruct.jl/src/xsd_reader/xsd_reader_complex_node.jl
+++ b/XsdToStruct.jl/src/xsd_reader/xsd_reader_complex_node.jl
@@ -104,12 +104,18 @@ function parse_xsd_complex_content_choice!(complex_node::ComplexTreeNode, xsd_ch
         parse_complex_content!(tmp_complex_node, child_element)
     end
 
+    choice_options = get_all_fields(tmp_complex_node)
+    group_option_index = findfirst(field -> field isa GroupFieldData, choice_options)
+    if !isnothing(group_option_index)
+        error(
+            "Xsd group refs inside a <choice> element are not supported (choice \"$choice_name\" references group " *
+            "\"$(choice_options[group_option_index].name)\"). Expand the group's contents inline in the xsd as a " *
+            "workaround.",
+        )
+    end
+
     # create choice field object
-    field = ChoiceFieldData(
-        name = field_name,
-        choice_options = get_all_fields(tmp_complex_node),
-        xsd_attributes = attributes_dict(xsd_choice),
-    )
+    field = ChoiceFieldData(name = field_name, choice_options = choice_options, xsd_attributes = attributes_dict(xsd_choice))
 
     # update parent node
     push!(complex_node.fields, field)

--- a/XsdToStruct.jl/test/test_data/edge_cases/group_ref_in_choice.xsd
+++ b/XsdToStruct.jl/test/test_data/edge_cases/group_ref_in_choice.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:TestChoiceGroup="TestChoiceGroup" targetNamespace="TestChoiceGroup">
+
+<element name="document" type="TestChoiceGroup:documentType"/>
+
+<group name="TestGroup1">
+    <sequence>
+        <element name="Element_string" type="string"/>
+        <element name="Element_double" type="double"/>
+    </sequence>
+</group>
+
+<complexType name="documentType">
+    <choice>
+        <group ref="TestChoiceGroup:TestGroup1"/>
+        <element name="Element_boolean" type="boolean"/>
+    </choice>
+</complexType>
+
+</schema>


### PR DESCRIPTION
## Summary
- A `<choice>` containing a `<group ref="..."/>` parses the group as a `GroupFieldData` placeholder alongside the choice's other `FieldData` options. `ChoiceFieldData.choice_options` is concretely typed as `Vector{FieldData}`, so building the choice field crashed with a cryptic `MethodError` deep in Base's array-conversion machinery (`Vector{FieldData}` cannot hold a `GroupFieldData`), matching the exact stack trace in the report.
- Group refs inside a choice aren't substituted anywhere: `substitute_group!` only resolves `GroupFieldData` placeholders sitting directly in a `ComplexTreeNode`'s `fields`, not inside the temporary node built while parsing a `<choice>`. So even loosening the field type wouldn't produce a meaningful `choice_options` entry - properly expanding a group's members as choice alternatives is a real feature with an open design question (a single choice alternative is normally one field, not a whole group of them).
- Rather than guess at that shape, this detects the case up front and raises a clear, specific error naming the offending choice and group, e.g.:
  > `Xsd group refs inside a <choice> element are not supported (choice "documentType" references group "TestGroup1"). Expand the group's contents inline in the xsd as a workaround.`

This matches what the issue reporter asked for directly: *"I think proper exception handling code should be added. When an error is thrown, it shows which part of the xsd caused the exception."*

Fixes #72

## Test plan
- [x] Reproduced the reported crash with a minimal `<choice>` + `<group ref>` schema, confirmed the exact same stack trace as the issue.
- [x] Verified the new code raises a clear `ErrorException` naming the choice and group instead.
- [x] Added `test/test_data/edge_cases/group_ref_in_choice.xsd`, which is exercised by the existing `xsd reader - edge cases` test loop (`@test_throws ErrorException`).
- [x] `Pkg.test()` passes (101 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)